### PR TITLE
sort `OrderedDict`s, not `Dict`s

### DIFF
--- a/src/modelVariables.jl
+++ b/src/modelVariables.jl
@@ -105,7 +105,7 @@ end
 
 function generateModelvars(featuresDict)
 
-    D = Dict(zip(featuresDict[:featureList],featuresDict[:powerBARSs]))
+    D = OrderedDict(zip(featuresDict[:featureList],featuresDict[:powerBARSs]))
     sortedD = sort(D, byvalue = true, rev=true)
 
     modelVariables = OrderedDict()


### PR DESCRIPTION
Currently, `OrderedDict` has a deprecated method to sort `Dict`'s via [type piracy](https://docs.julialang.org/en/v1/manual/style-guide/#Avoid-type-piracy). This piracy may be removed in https://github.com/JuliaCollections/OrderedCollections.jl/pull/110, which causes this method to error. Instead we can just construct an `OrderedDict` to sort instead.